### PR TITLE
enableBlocksTopo and disableBlocksTopo functions added

### DIFF
--- a/conman/CMakeLists.txt
+++ b/conman/CMakeLists.txt
@@ -70,8 +70,18 @@ install(DIRECTORY include/${PROJECT_NAME}/
 if (CATKIN_ENABLE_TESTING)
   find_library(GMOCK_LIBRARY REQUIRED NAMES gmock)
 
+
   catkin_add_gtest(test_conman tests/test_conman.cpp)
   target_link_libraries(test_conman 
+    conman 
+    conman_hook 
+    conman_components 
+    ${catkin_LIBRARIES} 
+    ${GMOCK_LIBRARY}
+    ${USE_OROCOS_LIBRARIES})
+
+  catkin_add_gtest(test_topo tests/test_topo.cpp)
+  target_link_libraries(test_topo
     conman 
     conman_hook 
     conman_components 

--- a/conman/include/conman/scheme.h
+++ b/conman/include/conman/scheme.h
@@ -496,6 +496,15 @@ namespace conman
     //! Print out the current execution ordering
     void printExecutionOrdering() const;
 
+    //Enable blocks in topological order (execution ordering)
+    bool enableBlocksTopo(
+        const bool strict,
+        const bool force);
+
+    //Disable blocks in reverse topological order
+    bool disableBlocksTopo(
+        const bool strict);
+
     //! Time state
     //TODO: use nsecs instead?
     RTT::Seconds

--- a/conman/include/conman/scheme.h
+++ b/conman/include/conman/scheme.h
@@ -327,7 +327,11 @@ namespace conman
         const std::vector<std::string> &block_names, 
         const bool strict,
         const bool force);
-
+    //Enable blocks in topological order (execution ordering)
+    bool enableBlocksTopo(
+        const std::vector<std::string> &blocks,
+        const bool strict,
+        const bool force);
     //! Disable a single conman Block
     bool disableBlock(RTT::TaskContext *block);
     //! Disable a single Conman block (or group) by name
@@ -337,6 +341,10 @@ namespace conman
     //! Disable multiple Conman blocks (or groups) by name simultaneously
     bool disableBlocks(
         const std::vector<std::string> &block_names,
+        const bool strict);
+    //Disable blocks in reverse topological order
+    bool disableBlocksTopo(
+        const std::vector<std::string> &blocks,
         const bool strict);
 
     /*** \brief Try to disable a set of blocks (or groups) and enable another
@@ -495,15 +503,6 @@ namespace conman
 
     //! Print out the current execution ordering
     void printExecutionOrdering() const;
-
-    //Enable blocks in topological order (execution ordering)
-    bool enableBlocksTopo(
-        const bool strict,
-        const bool force);
-
-    //Disable blocks in reverse topological order
-    bool disableBlocksTopo(
-        const bool strict);
 
     //! Time state
     //TODO: use nsecs instead?

--- a/conman/src/scheme.cpp
+++ b/conman/src/scheme.cpp
@@ -252,6 +252,53 @@ void Scheme::printExecutionOrdering() const
   RTT::log(RTT::Info) << "Scheme ordering: [ " <<
     boost::algorithm::join(ordered_names, ", ") << " ] " << RTT::endlog();
 }
+//////////////////////////////////////////////////////////////////////////////
+
+bool Scheme::enableBlocksTopo(const bool strict, const bool force)
+{
+  using namespace conman::graph;
+
+  std::vector<std::string> ordered_names;
+  ordered_names.reserve(exec_ordering_.size());
+
+  for(ExecutionOrdering::const_iterator it = exec_ordering_.begin();
+      it != exec_ordering_.end();
+      ++it) 
+  {
+    const std::string &block_name = flow_graph_[*it]->block->getName();
+    ordered_names.push_back(block_name);
+  }
+
+  std::vector<std::string> &ordered_names_addr = ordered_names;
+ 
+  return this->enableBlocks(ordered_names_addr, strict, force);
+
+  //RTT::log(RTT::Info) << "Scheme ordering: [ " <<
+  //  boost::algorithm::join(ordered_names, ", ") << " ] " << RTT::endlog();
+}
+
+bool Scheme::disableBlocksTopo(const bool strict)
+{
+  using namespace conman::graph;
+
+  std::vector<std::string> ordered_names;
+  ordered_names.reserve(exec_ordering_.size());
+
+  for(ExecutionOrdering::const_iterator it = exec_ordering_.end();
+      it != exec_ordering_.begin();
+      --it) 
+  {
+    const std::string &block_name = flow_graph_[*it]->block->getName();
+    ordered_names.push_back(block_name);
+  }
+
+  std::vector<std::string> &ordered_names_addr = ordered_names;
+ 
+  return this->disableBlocks(ordered_names_addr, strict);
+ 
+  //RTT::log(RTT::Info) << "Scheme ordering: [ " <<
+  //  boost::algorithm::join(ordered_names, ", ") << " ] " << RTT::endlog();
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/conman/src/scheme.cpp
+++ b/conman/src/scheme.cpp
@@ -1731,19 +1731,27 @@ bool Scheme::enableBlocksTopo(
   std::vector<std::string> ordered_names;
   ordered_names.reserve(exec_ordering_.size());
 
+  // Create non const vector of blocks from parameter so we can add 
+  // a new last element and use std::find
+  std::vector<std::string> non_const = unordered;
+  non_const.push_back("/0");
+
+  //Goes through all blocks in execution order, if that block is also
+  //in list of blocks to enable, it is put in the new ordered vector
   for(ExecutionOrdering::const_iterator it = exec_ordering_.begin();
       it != exec_ordering_.end();
       ++it) 
   {
     const std::string &block_name = flow_graph_[*it]->block->getName();
-    if(std::find(unordered.begin(), unordered.end(), block_name) != unordered.end())
+    if(std::find(non_const.begin(), non_const.end(), block_name) != non_const.end())
     {
       ordered_names.push_back(block_name);
     }
   }
 
   std::vector<std::string> &ordered_names_addr = ordered_names;
- 
+
+  //Send ordered list of blocks to enableBlocks function
   return this->enableBlocks(ordered_names_addr, strict, force);
 }
 
@@ -1794,19 +1802,30 @@ bool Scheme::disableBlocksTopo(
   std::vector<std::string> ordered_names;
   ordered_names.reserve(exec_ordering_.size());
 
-  for(ExecutionOrdering::const_iterator it = exec_ordering_.end();
-      it != exec_ordering_.begin();
-      --it) 
+  //Create non const list of unordered blocks to disable so we can add new
+  //arbitrary last element and then use std::find
+  std::vector<std::string> non_const = unordered;
+  non_const.push_back("/0");
+
+  //Go through all blocks in scheme in execution order, if block is in the
+  //list to disable, add to new ordered list.
+  for(ExecutionOrdering::const_iterator it = exec_ordering_.begin();
+      it != exec_ordering_.end();
+      ++it) 
   {
     const std::string &block_name = flow_graph_[*it]->block->getName();
-    if(std::find(unordered.begin(), unordered.end(), block_name) != unordered.end())
+    if(std::find(non_const.begin(), non_const.end(), block_name) != non_const.end())
     {
       ordered_names.push_back(block_name);
     }
   }
 
+  //We want to disable in reverse execution order to reverse the ordered list
+  std::reverse(ordered_names.begin(), ordered_names.end());
+    
   std::vector<std::string> &ordered_names_addr = ordered_names;
- 
+  
+  //Call function disableBlocks with new ordered list
   return this->disableBlocks(ordered_names_addr, strict);
 }
 

--- a/conman/src/scheme.cpp
+++ b/conman/src/scheme.cpp
@@ -252,53 +252,6 @@ void Scheme::printExecutionOrdering() const
   RTT::log(RTT::Info) << "Scheme ordering: [ " <<
     boost::algorithm::join(ordered_names, ", ") << " ] " << RTT::endlog();
 }
-//////////////////////////////////////////////////////////////////////////////
-
-bool Scheme::enableBlocksTopo(const bool strict, const bool force)
-{
-  using namespace conman::graph;
-
-  std::vector<std::string> ordered_names;
-  ordered_names.reserve(exec_ordering_.size());
-
-  for(ExecutionOrdering::const_iterator it = exec_ordering_.begin();
-      it != exec_ordering_.end();
-      ++it) 
-  {
-    const std::string &block_name = flow_graph_[*it]->block->getName();
-    ordered_names.push_back(block_name);
-  }
-
-  std::vector<std::string> &ordered_names_addr = ordered_names;
- 
-  return this->enableBlocks(ordered_names_addr, strict, force);
-
-  //RTT::log(RTT::Info) << "Scheme ordering: [ " <<
-  //  boost::algorithm::join(ordered_names, ", ") << " ] " << RTT::endlog();
-}
-
-bool Scheme::disableBlocksTopo(const bool strict)
-{
-  using namespace conman::graph;
-
-  std::vector<std::string> ordered_names;
-  ordered_names.reserve(exec_ordering_.size());
-
-  for(ExecutionOrdering::const_iterator it = exec_ordering_.end();
-      it != exec_ordering_.begin();
-      --it) 
-  {
-    const std::string &block_name = flow_graph_[*it]->block->getName();
-    ordered_names.push_back(block_name);
-  }
-
-  std::vector<std::string> &ordered_names_addr = ordered_names;
- 
-  return this->disableBlocks(ordered_names_addr, strict);
- 
-  //RTT::log(RTT::Info) << "Scheme ordering: [ " <<
-  //  boost::algorithm::join(ordered_names, ", ") << " ] " << RTT::endlog();
-}
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -1768,6 +1721,32 @@ bool Scheme::enableBlocks(
   return success;
 }
 
+bool Scheme::enableBlocksTopo(
+    const std::vector<std::string> &unordered, 
+    const bool strict, 
+    const bool force)
+{
+  using namespace conman::graph;
+
+  std::vector<std::string> ordered_names;
+  ordered_names.reserve(exec_ordering_.size());
+
+  for(ExecutionOrdering::const_iterator it = exec_ordering_.begin();
+      it != exec_ordering_.end();
+      ++it) 
+  {
+    const std::string &block_name = flow_graph_[*it]->block->getName();
+    if(std::find(unordered.begin(), unordered.end(), block_name) != unordered.end())
+    {
+      ordered_names.push_back(block_name);
+    }
+  }
+
+  std::vector<std::string> &ordered_names_addr = ordered_names;
+ 
+  return this->enableBlocks(ordered_names_addr, strict, force);
+}
+
 bool Scheme::disableBlocks(const bool strict)
 {
   bool success = true;
@@ -1805,6 +1784,32 @@ bool Scheme::disableBlocks(
 
   return success;
 }
+
+bool Scheme::disableBlocksTopo(
+    const std::vector<std::string> &unordered, 
+    const bool strict)
+{
+  using namespace conman::graph;
+
+  std::vector<std::string> ordered_names;
+  ordered_names.reserve(exec_ordering_.size());
+
+  for(ExecutionOrdering::const_iterator it = exec_ordering_.end();
+      it != exec_ordering_.begin();
+      --it) 
+  {
+    const std::string &block_name = flow_graph_[*it]->block->getName();
+    if(std::find(unordered.begin(), unordered.end(), block_name) != unordered.end())
+    {
+      ordered_names.push_back(block_name);
+    }
+  }
+
+  std::vector<std::string> &ordered_names_addr = ordered_names;
+ 
+  return this->disableBlocks(ordered_names_addr, strict);
+}
+
 
 bool Scheme::switchBlocks(
     const std::vector<std::string> &disable_block_names,

--- a/conman/tests/test_topo.cpp
+++ b/conman/tests/test_topo.cpp
@@ -1,0 +1,489 @@
+/** Copyright (c) 2013, Jonathan Bohren, all rights reserved. 
+ * This software is released under the BSD 3-clause license, for the details of
+ * this license, please see LICENSE.txt at the root of this repository. 
+ */
+
+#include <string>
+#include <vector>
+#include <iterator>
+
+#include <rtt/os/startstop.h>
+
+#include <ocl/DeploymentComponent.hpp>
+#include <ocl/TaskBrowser.hpp>
+#include <ocl/LoggingService.hpp>
+#include <rtt/Logger.hpp>
+#include <rtt/deployment/ComponentLoader.hpp>
+
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/topological_sort.hpp>
+
+#include <conman/conman.h>
+#include <conman/scheme.h>
+#include <conman/hook.h>
+
+#include <boost/assign/std/vector.hpp>
+using namespace boost::assign;
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+using ::testing::ElementsAre;
+
+
+class InvalidBlock : public RTT::TaskContext {
+public:
+  InvalidBlock(const std::string &name) : RTT::TaskContext(name) { }
+};
+
+class ValidBlock : public RTT::TaskContext {
+public:
+  ValidBlock(const std::string &name) : RTT::TaskContext(name) { 
+    conman_hook_ = conman::Hook::GetHook(this);
+  }
+  boost::shared_ptr<conman::Hook> conman_hook_;
+};
+
+class IOBlock : public RTT::TaskContext {
+public:
+  RTT::InputPort<double> in;
+  RTT::InputPort<double> in_ex;
+
+  RTT::OutputPort<double> out1;
+  RTT::OutputPort<double> out2;
+
+  IOBlock(const std::string &name) : RTT::TaskContext(name) { 
+    this->addPort("in",in);
+    this->addPort("in_ex",in_ex);
+
+    this->addPort("out1",out1);
+    this->addPort("out2",out2);
+
+    conman_hook_ = conman::Hook::GetHook(this);
+    conman_hook_->setInputExclusivity("in_ex",conman::Exclusivity::EXCLUSIVE);
+  }
+
+  boost::shared_ptr<conman::Hook> conman_hook_;
+};
+
+class SchemeTest : public ::testing::Test {
+protected:
+  SchemeTest() : scheme("Scheme") { }
+
+  conman::Scheme scheme;
+};
+
+TEST_F(SchemeTest, Init) {
+  std::vector<std::vector<std::string> > cycles;
+  EXPECT_EQ(scheme.getFlowCycles(cycles),0);
+  EXPECT_EQ(cycles.size(),0);
+
+  EXPECT_EQ(scheme.getExecutionCycles(cycles),0);
+  EXPECT_EQ(cycles.size(),0);
+
+  std::vector<std::string> path;
+  EXPECT_EQ(scheme.latchCount(path),0);
+
+  EXPECT_EQ(scheme.maxLatchCount(),0);
+  EXPECT_EQ(scheme.minLatchCount(),0);
+
+  EXPECT_EQ(scheme.executable(),true);
+}
+
+class BlocksTest : public SchemeTest { };
+
+TEST_F(BlocksTest, GetBlocks) {
+  std::vector<std::string> blocks;
+  
+  blocks = scheme.getBlocks();
+  EXPECT_EQ(blocks.size(),0);
+
+  scheme.getBlocks(blocks);
+  EXPECT_EQ(blocks.size(),0);
+}
+
+TEST_F(BlocksTest, AddBlocks) {
+  EXPECT_FALSE(scheme.addBlock(""));
+  EXPECT_FALSE(scheme.addBlock("fail"));
+  EXPECT_FALSE(scheme.addBlock(NULL));
+
+  InvalidBlock ib1("ib1");
+  EXPECT_TRUE(scheme.addBlock(&ib1));
+  EXPECT_EQ(scheme.getBlocks().size(),1);
+
+  ValidBlock vb1("vb1");
+  EXPECT_FALSE(scheme.addBlock("vb1"));
+  EXPECT_TRUE(scheme.addPeer(&vb1));
+  EXPECT_TRUE(scheme.addBlock("vb1"));
+  EXPECT_EQ(scheme.getBlocks().size(),2);
+
+  ValidBlock vb2("vb2");
+  EXPECT_TRUE(scheme.addBlock(&vb2));
+
+  EXPECT_EQ(scheme.getBlocks().size(),3);
+}
+
+TEST_F(BlocksTest, RemoveBlocks) {
+  EXPECT_FALSE(scheme.removeBlock(""));
+  EXPECT_FALSE(scheme.removeBlock("fail"));
+  EXPECT_FALSE(scheme.removeBlock(NULL));
+
+  ValidBlock vb1("vb1");
+  EXPECT_TRUE(scheme.addPeer(&vb1));
+  EXPECT_TRUE(scheme.removeBlock("vb1"));
+  EXPECT_EQ(scheme.getBlocks().size(),0);
+}
+
+TEST_F(BlocksTest, StartAddBlocks) {
+
+  scheme.start();
+
+  ValidBlock vb1("vb1");
+  EXPECT_TRUE(scheme.addPeer(&vb1));
+  EXPECT_FALSE(scheme.addBlock("vb1"));
+  EXPECT_FALSE(scheme.addBlock(&vb1));
+  EXPECT_EQ(scheme.getBlocks().size(),0);
+
+  scheme.stop();
+
+  ValidBlock vb2("vb2");
+  EXPECT_TRUE(scheme.addBlock("vb1"));
+  EXPECT_TRUE(scheme.addBlock(&vb2));
+
+  EXPECT_EQ(scheme.getBlocks().size(),2);
+}
+
+TEST_F(BlocksTest, StartRemoveBlocks) {
+
+  ValidBlock vb1("vb1");
+  scheme.addBlock(&vb1);
+  scheme.start();
+  
+  EXPECT_FALSE(scheme.removeBlock("vb1"));
+  EXPECT_EQ(scheme.getBlocks().size(),1);
+  
+  scheme.stop();
+  
+  EXPECT_TRUE(scheme.removeBlock("vb1"));
+  EXPECT_EQ(scheme.getBlocks().size(),0);
+}
+
+class GroupsTest : public SchemeTest { 
+public:
+  GroupsTest() : SchemeTest(),
+    vb1("vb1"),
+    vb2("vb2"),
+    vb3("vb3")
+  {
+    scheme.addBlock(&vb1);
+    scheme.addBlock(&vb2);
+    scheme.addBlock(&vb3);
+  }
+
+  ValidBlock vb1;
+  ValidBlock vb2;
+  ValidBlock vb3;
+};
+
+TEST_F(GroupsTest, GetGroups) {
+  EXPECT_FALSE(scheme.hasGroup("fail"));
+
+  std::vector<std::string> members;
+  EXPECT_FALSE(scheme.getGroupMembers("fail",members));
+}
+
+TEST_F(GroupsTest, AddGroups) {
+  EXPECT_TRUE(scheme.addGroup(""));
+  EXPECT_TRUE(scheme.addGroup("win"));
+  EXPECT_TRUE(scheme.addGroup("win"));
+}
+
+TEST_F(GroupsTest, SetGroups) {
+  std::vector<std::string> members;
+
+  EXPECT_TRUE(scheme.setGroupMembers("",members));
+  EXPECT_TRUE(scheme.setGroupMembers("win",members));
+
+  members.push_back("not_a_peer");
+  EXPECT_FALSE(scheme.setGroupMembers("fail",members));
+
+}
+
+TEST_F(GroupsTest, AddToGroups) {
+  std::vector<std::string> members, members_get;
+
+  EXPECT_FALSE(scheme.addToGroup("fail",""));
+
+  EXPECT_FALSE(scheme.addToGroup("vb1","win"));
+  EXPECT_TRUE(scheme.addGroup("win"));
+  EXPECT_TRUE(scheme.addToGroup("vb1","win"));
+  EXPECT_TRUE(scheme.addToGroup("vb2","win"));
+  // Add it again
+  EXPECT_TRUE(scheme.addToGroup("vb2","win"));
+
+  EXPECT_TRUE(scheme.getGroupMembers("win",members_get));
+  EXPECT_EQ(members_get.size(),2);
+
+  EXPECT_THAT(members_get, ElementsAre("vb1","vb2"));
+}
+
+TEST_F(GroupsTest, NestedGroups) {
+  std::vector<std::string> members, members_get;
+
+  EXPECT_TRUE(scheme.setGroupMembers("win1","vb1"));
+  EXPECT_TRUE(scheme.setGroupMembers("win2","vb2"));
+  EXPECT_TRUE(scheme.setGroupMembers("win3","vb3"));
+  EXPECT_TRUE(scheme.addGroup("win4"));
+
+  std::vector<std::string> win123_members;
+  win123_members += "win1", "win2", "win3", "win4", "win123";
+
+  EXPECT_TRUE(scheme.setGroupMembers("win123",win123_members));
+
+  EXPECT_TRUE(scheme.getGroupMembers("win123",members_get));
+  EXPECT_EQ(members_get.size(),3);
+}
+
+TEST_F(GroupsTest, RemoveFromGroups) {
+  std::vector<std::string> members, members_get;
+
+  // Add some members
+  EXPECT_TRUE(scheme.setGroupMembers("win1","vb1"));
+  EXPECT_TRUE(scheme.addToGroup("vb2","win1"));
+  EXPECT_TRUE(scheme.getGroupMembers("win1",members_get));
+  EXPECT_EQ(members_get.size(),2);
+
+  // Remove a member
+  EXPECT_TRUE(scheme.removeFromGroup("vb2","win1"));
+  EXPECT_TRUE(scheme.getGroupMembers("win1",members_get));
+  EXPECT_EQ(members_get.size(),1);
+  
+  // Empty the group
+  EXPECT_TRUE(scheme.emptyGroup("win1"));
+  EXPECT_TRUE(scheme.getGroupMembers("win1",members_get));
+  EXPECT_EQ(members_get.size(),0);
+
+  // Empty it again (already empty)
+  EXPECT_TRUE(scheme.emptyGroup("win1"));
+  EXPECT_TRUE(scheme.getGroupMembers("win1",members_get));
+  EXPECT_EQ(members_get.size(),0);
+}
+
+class DataFlowTest : public SchemeTest { 
+public:
+  IOBlock iob1;
+  IOBlock iob2;
+  IOBlock iob3;
+  IOBlock iob4;
+  IOBlock iob5;
+
+  // Expected cycles
+  std::vector<std::string> c1,c2,c3,c4;
+
+  DataFlowTest() : SchemeTest(),
+    iob1("iob1"),
+    iob2("iob2"),
+    iob3("iob3"),
+    iob4("iob4"),
+    iob5("iob5")
+  {
+    // Expected cycles
+    c1 += "iob1", "iob2", "iob3", "iob4", "iob5";
+    c2 += "iob1", "iob3", "iob4", "iob5";
+    c3 += "iob1", "iob5";
+    c4 += "iob2", "iob3", "iob4", "iob5";
+  }
+
+  void AddBlocks() {
+    scheme.addBlock(&iob1);
+    scheme.addBlock(&iob2);
+    scheme.addBlock(&iob3);
+    scheme.addBlock(&iob4);
+    scheme.addBlock(&iob5);
+  }
+
+  void ConnectBlocksAcyclic() {
+    iob1.out1.connectTo(&iob2.in);
+    iob1.out2.connectTo(&iob3.in_ex);
+    iob2.out1.connectTo(&iob3.in_ex);
+    iob2.out2.connectTo(&iob3.in);
+    iob3.out1.connectTo(&iob4.in);
+    iob1.out1.connectTo(&iob5.in);
+    iob4.out1.connectTo(&iob5.in);
+  }
+
+  void ConnectBlocksCyclic() {
+    iob5.out1.connectTo(&iob1.in);
+    iob5.out2.connectTo(&iob2.in);
+  }
+
+  void PrintCycles(std::vector<std::vector<std::string> > &cycles) {
+    std::cerr<<"cycles: "<<std::endl;
+    for(size_t i=0; i<cycles.size(); i++) {
+      std::cerr<<"  [";
+      for(size_t v=0; v < cycles[i].size(); v++) {
+        std::cerr<<" "<<cycles[i][v];
+      }
+      std::cerr<<" ]"<<std::endl;
+    }
+  }
+};
+
+TEST_F(DataFlowTest, Acyclic) {
+  // Connect blocks without cycles
+  ConnectBlocksAcyclic();
+  AddBlocks();
+  EXPECT_TRUE(scheme.executable());
+}
+
+TEST_F(DataFlowTest, Cyclic) {
+  // Connect blocks without cycles
+  ConnectBlocksAcyclic();
+  AddBlocks();
+  EXPECT_TRUE(scheme.executable());
+  // Add some cycles
+  ConnectBlocksCyclic();
+  // At this point the model is out-of-sync with the actual DFG
+  EXPECT_TRUE(scheme.executable());
+  scheme.regenerateModel();
+  EXPECT_FALSE(scheme.executable());
+}
+
+TEST_F(DataFlowTest, GetCycles) {
+  // Connect blocks with cycles
+  ConnectBlocksAcyclic();
+  ConnectBlocksCyclic();
+  AddBlocks();
+  EXPECT_FALSE(scheme.executable());
+
+  // Get the cycles
+  std::vector<std::vector<std::string> > flow_cycles, exec_cycles;
+
+  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
+  EXPECT_THAT(flow_cycles, ElementsAre(c1,c2,c3,c4));
+
+  //PrintCycles(flow_cycles);
+
+  EXPECT_EQ(4,scheme.getExecutionCycles(exec_cycles));
+  EXPECT_THAT(exec_cycles, ElementsAre(c1,c2,c3,c4));
+}
+
+TEST_F(DataFlowTest, LatchConnections) {
+  std::vector<std::vector<std::string> > flow_cycles, exec_cycles;
+
+  // Connect blocks with cycles
+  ConnectBlocksAcyclic();
+  ConnectBlocksCyclic();
+  AddBlocks();
+
+  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
+  EXPECT_THAT(flow_cycles, ElementsAre(c1,c2,c3,c4));
+  EXPECT_EQ(4,scheme.getExecutionCycles(exec_cycles));
+  EXPECT_THAT(exec_cycles, ElementsAre(c1,c2,c3,c4));
+
+  EXPECT_TRUE(scheme.latchConnections("iob5","iob1",true));
+
+  EXPECT_FALSE(scheme.executable());
+
+  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
+  EXPECT_THAT(flow_cycles, ElementsAre(c1,c2,c3,c4));
+  EXPECT_EQ(1,scheme.getExecutionCycles(exec_cycles));
+  EXPECT_THAT(exec_cycles, ElementsAre(c4));
+
+  EXPECT_TRUE(scheme.latchConnections("iob5","iob2",true));
+
+  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
+  EXPECT_THAT(flow_cycles, ElementsAre(c1,c2,c3,c4));
+  EXPECT_EQ(0,scheme.getExecutionCycles(exec_cycles));
+  EXPECT_TRUE(scheme.executable());
+
+  std::vector<std::string> execution_order;
+
+  EXPECT_TRUE(scheme.getExecutionOrder(execution_order));
+
+  EXPECT_THAT(execution_order, ElementsAre("iob1", "iob2", "iob3", "iob4", "iob5"));
+}
+
+TEST_F(DataFlowTest, Latchanalysis) {
+  std::vector<std::vector<std::string> > flow_cycles, exec_cycles;
+
+  // Connect blocks with cycles
+  ConnectBlocksAcyclic();
+  ConnectBlocksCyclic();
+  AddBlocks();
+
+  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
+  EXPECT_EQ(4,scheme.getExecutionCycles(exec_cycles));
+
+  scheme.latchConnections("iob5","iob1",true);
+  scheme.latchConnections("iob5","iob2",true);
+
+  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
+  EXPECT_EQ(0,scheme.getExecutionCycles(exec_cycles));
+
+  std::vector<std::string> path_query1, path_query2;
+  path_query1 += "iob1", "iob2", "iob3", "iob4", "iob5";
+  EXPECT_EQ(0,scheme.latchCount(path_query1));
+  path_query2 += "iob5","iob1";
+  EXPECT_EQ(1,scheme.latchCount(path_query2));
+
+  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
+  EXPECT_EQ(0,scheme.getExecutionCycles(exec_cycles));
+
+  EXPECT_EQ(1,scheme.maxLatchCount());
+  EXPECT_EQ(1,scheme.minLatchCount());
+}
+
+TEST_F(DataFlowTest, StartAcyclic) {
+  // Connect blocks without cycles
+  ConnectBlocksAcyclic();
+  AddBlocks();
+  EXPECT_TRUE(scheme.start());
+}
+
+TEST_F(DataFlowTest, StartCyclic) {
+  // Connect blocks without cycles
+  ConnectBlocksAcyclic();
+  AddBlocks();
+  EXPECT_TRUE(scheme.start());
+  scheme.stop();
+  // Add some cycles
+  ConnectBlocksCyclic();
+  EXPECT_FALSE(scheme.start());
+}
+
+TEST_F(DataFlowTest, StartLatchConnections) {
+  std::vector<std::vector<std::string> > flow_cycles, exec_cycles;
+
+  // Connect blocks with cycles
+  ConnectBlocksAcyclic();
+
+  AddBlocks();
+
+  scheme.start();
+
+  ConnectBlocksCyclic();
+  EXPECT_FALSE(scheme.regenerateModel());
+  EXPECT_FALSE(scheme.latchConnections("iob5","iob1",true));
+
+  scheme.stop();
+  EXPECT_FALSE(scheme.regenerateModel());
+  EXPECT_TRUE(scheme.latchConnections("iob5","iob1",true));
+  EXPECT_TRUE(scheme.latchConnections("iob5","iob2",true));
+  EXPECT_TRUE(scheme.regenerateModel());
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+
+  // Initialize Orocos
+  __os_init(argc, argv);
+
+  RTT::Logger::log().setStdStream(std::cerr);
+  RTT::Logger::log().mayLogStdOut(true);
+  //RTT::Logger::log().setLogLevel(RTT::Logger::Info);
+
+  // Import conman plugin
+  RTT::ComponentLoader::Instance()->import("conman", "" );
+
+  return RUN_ALL_TESTS();
+}

--- a/conman/tests/test_topo.cpp
+++ b/conman/tests/test_topo.cpp
@@ -3,6 +3,8 @@
  * * this license, please see LICENSE.txt at the root of this repository.
  * */
 
+#include <iostream>
+
 #include <string>
 #include <vector>
 #include <iterator>
@@ -31,19 +33,6 @@ using ::testing::ElementsAre;
 
 std::vector<std::string> enable_Order;
 std::vector<std::string> disable_Order;
-
-class InvalidBlock : public RTT::TaskContext {
-public:
-  InvalidBlock(const std::string &name) : RTT::TaskContext(name) { }
-};
-
-class ValidBlock : public RTT::TaskContext {
-public:
-  ValidBlock(const std::string &name) : RTT::TaskContext(name) {
-    conman_hook_ = conman::Hook::GetHook(this);
-  }
-  boost::shared_ptr<conman::Hook> conman_hook_;
-};
 
 class IOBlock : public RTT::TaskContext {
 public:
@@ -120,19 +109,9 @@ public:
   void ConnectBlocksCyclic() {
     iob5.out1.connectTo(&iob1.in);
   }
-
-  void PrintCycles(std::vector<std::vector<std::string> > &cycles) {
-    std::cerr<<"cycles: "<<std::endl;
-    for(size_t i=0; i<cycles.size(); i++) {
-      std::cerr<<" [";
-      for(size_t v=0; v < cycles[i].size(); v++) {
-        std::cerr<<" "<<cycles[i][v];
-      }
-      std::cerr<<" ]"<<std::endl;
-    }
-  }
 };
 
+/*Test start hook that contains the order of blocks enabled. */
 TEST_F(TopoTest, EnableOrder) {
   //setup blocks, connected 1 -> 2 -> 3 -> 4 -> 5 -latched-> 1
   ConnectBlocksAcyclic();
@@ -154,6 +133,7 @@ TEST_F(TopoTest, EnableOrder) {
   disable_Order.clear();
 }
 
+/*Test stop hook that contains the order of blocks disabled. */
 TEST_F(TopoTest, DisableOrder) {
   //setup blocks, connected 1 -> 2 -> 3 -> 4 -> 5 -latched-> 1
   ConnectBlocksAcyclic();
@@ -176,6 +156,7 @@ TEST_F(TopoTest, DisableOrder) {
   disable_Order.clear();
 }
 
+/* Test that enableBlocksTopo does indeed inable the blocks. */
 TEST_F(TopoTest, TopoEnable) {
   //setup blocks, connected 1 -> 2 -> 3 -> 4 -> 5 -latched-> 1
   ConnectBlocksAcyclic();
@@ -190,15 +171,16 @@ TEST_F(TopoTest, TopoEnable) {
 
   EXPECT_TRUE(scheme.enableBlocksTopo(ptr_blocks, true, true));
   EXPECT_THAT(enable_Order, ElementsAre("iob1", "iob2", "iob3", "iob4", "iob5"));
-
+ 
   EXPECT_TRUE(scheme.disableBlocks(ptr_blocks, true));
-
+ 
   scheme.stop();
   enable_Order.clear();
   disable_Order.clear();
 }
 
-TEST_F(TopoTest, TopoEnableRand) {
+/*Test that disableBlocksTopo disables blocks. */
+TEST_F(TopoTest, TopoDisable) {
   //setup blocks, connected 1 -> 2 -> 3 -> 4 -> 5 -latched-> 1
   ConnectBlocksAcyclic();
   ConnectBlocksCyclic();
@@ -206,17 +188,69 @@ TEST_F(TopoTest, TopoEnableRand) {
   scheme.latchConnections("iob5","iob1",true);
   std::vector<std::string> execution_order;
   scheme.getExecutionOrder(execution_order);
+   
+  scheme.start();
+  std::vector<std::string> &ptr_blocks = execution_order;
+  EXPECT_TRUE(scheme.enableBlocks(ptr_blocks, false, false));
+
+  std::vector<std::string> reverse_order = execution_order;
+  std::reverse(reverse_order.begin(), reverse_order.end());
+  std::vector<std::string> &ptr_blocks_reverse = reverse_order;
+
+  EXPECT_TRUE(scheme.disableBlocksTopo(ptr_blocks_reverse, true));
+  EXPECT_THAT(disable_Order, ElementsAre("iob5", "iob4", "iob3", "iob2", "iob1"));
+
+  scheme.stop();
+  enable_Order.clear();
+  disable_Order.clear();
+}
+
+/*Test that enableBlocksTopo enables blocks in the correct order 
+ * when they were provided in the wrong order. */
+TEST_F(TopoTest, TopoEnableUnordered) {
+  //setup blocks, connected 1 -> 2 -> 3 -> 4 -> 5 -latched-> 1
+  ConnectBlocksAcyclic();
+  ConnectBlocksCyclic();
+  AddBlocks();
+  scheme.latchConnections("iob5","iob1",true);
+  std::vector<std::string> execution_order;
+  scheme.getExecutionOrder(execution_order);
+  std::vector<std::string> &ptr_blocks = execution_order;
+
+  scheme.start();
+  std::vector<std::string> reverse_order = execution_order;
+  std::reverse(reverse_order.begin(), reverse_order.end());
+  std::vector<std::string> &ptr_blocks_reverse = reverse_order;
+
+  EXPECT_TRUE(scheme.enableBlocksTopo(ptr_blocks_reverse, true, true));
+  EXPECT_THAT(enable_Order, ElementsAre("iob1", "iob2", "iob3", "iob4", "iob5"));
+  
+  EXPECT_TRUE(scheme.disableBlocks(ptr_blocks, true));
+
+  scheme.stop();
+  enable_Order.clear();
+  disable_Order.clear();
+}
+
+/*Test that disableBlocksTopo disables blocks in the correct order
+ * when they are provided in the wrng order. */
+TEST_F(TopoTest, TopoDisableUnordered) {
+  //setup blocks, connected 1 -> 2 -> 3 -> 4 -> 5 -latched-> 1
+  ConnectBlocksAcyclic();
+  ConnectBlocksCyclic();
+  AddBlocks();
+  scheme.latchConnections("iob5","iob1",true);
+  std::vector<std::string> execution_order;
+  scheme.getExecutionOrder(execution_order);
+  std::vector<std::string> &ptr_blocks = execution_order;
 
   scheme.start();
 
-  std::vector<std::string> random_order;
-  random_order += "io4", "io1", "io5", "io3", "io2";
-  std::vector<std::string> &ptr_blocks = random_order; 
-
-  EXPECT_TRUE(scheme.enableBlocksTopo(ptr_blocks, true, true));
-  //EXPECT_THAT(enable_Order, ElementsAre("iob1", "iob2", "iob3", "iob4", "iob5"));
+  EXPECT_TRUE(scheme.enableBlocks(ptr_blocks, true, true));
   
-  //EXPECT_TRUE(scheme.disableBlocks(ptr_blocks, true));
+  EXPECT_TRUE(scheme.disableBlocksTopo(ptr_blocks, true));
+  EXPECT_EQ(disable_Order.size(), 5);
+  EXPECT_THAT(disable_Order, ElementsAre("iob5", "iob4", "iob3", "iob2", "iob1")); 
 
   scheme.stop();
   enable_Order.clear();

--- a/conman/tests/test_topo.cpp
+++ b/conman/tests/test_topo.cpp
@@ -72,203 +72,7 @@ protected:
   conman::Scheme scheme;
 };
 
-TEST_F(SchemeTest, Init) {
-  std::vector<std::vector<std::string> > cycles;
-  EXPECT_EQ(scheme.getFlowCycles(cycles),0);
-  EXPECT_EQ(cycles.size(),0);
-
-  EXPECT_EQ(scheme.getExecutionCycles(cycles),0);
-  EXPECT_EQ(cycles.size(),0);
-
-  std::vector<std::string> path;
-  EXPECT_EQ(scheme.latchCount(path),0);
-
-  EXPECT_EQ(scheme.maxLatchCount(),0);
-  EXPECT_EQ(scheme.minLatchCount(),0);
-
-  EXPECT_EQ(scheme.executable(),true);
-}
-
-class BlocksTest : public SchemeTest { };
-
-TEST_F(BlocksTest, GetBlocks) {
-  std::vector<std::string> blocks;
-  
-  blocks = scheme.getBlocks();
-  EXPECT_EQ(blocks.size(),0);
-
-  scheme.getBlocks(blocks);
-  EXPECT_EQ(blocks.size(),0);
-}
-
-TEST_F(BlocksTest, AddBlocks) {
-  EXPECT_FALSE(scheme.addBlock(""));
-  EXPECT_FALSE(scheme.addBlock("fail"));
-  EXPECT_FALSE(scheme.addBlock(NULL));
-
-  InvalidBlock ib1("ib1");
-  EXPECT_TRUE(scheme.addBlock(&ib1));
-  EXPECT_EQ(scheme.getBlocks().size(),1);
-
-  ValidBlock vb1("vb1");
-  EXPECT_FALSE(scheme.addBlock("vb1"));
-  EXPECT_TRUE(scheme.addPeer(&vb1));
-  EXPECT_TRUE(scheme.addBlock("vb1"));
-  EXPECT_EQ(scheme.getBlocks().size(),2);
-
-  ValidBlock vb2("vb2");
-  EXPECT_TRUE(scheme.addBlock(&vb2));
-
-  EXPECT_EQ(scheme.getBlocks().size(),3);
-}
-
-TEST_F(BlocksTest, RemoveBlocks) {
-  EXPECT_FALSE(scheme.removeBlock(""));
-  EXPECT_FALSE(scheme.removeBlock("fail"));
-  EXPECT_FALSE(scheme.removeBlock(NULL));
-
-  ValidBlock vb1("vb1");
-  EXPECT_TRUE(scheme.addPeer(&vb1));
-  EXPECT_TRUE(scheme.removeBlock("vb1"));
-  EXPECT_EQ(scheme.getBlocks().size(),0);
-}
-
-TEST_F(BlocksTest, StartAddBlocks) {
-
-  scheme.start();
-
-  ValidBlock vb1("vb1");
-  EXPECT_TRUE(scheme.addPeer(&vb1));
-  EXPECT_FALSE(scheme.addBlock("vb1"));
-  EXPECT_FALSE(scheme.addBlock(&vb1));
-  EXPECT_EQ(scheme.getBlocks().size(),0);
-
-  scheme.stop();
-
-  ValidBlock vb2("vb2");
-  EXPECT_TRUE(scheme.addBlock("vb1"));
-  EXPECT_TRUE(scheme.addBlock(&vb2));
-
-  EXPECT_EQ(scheme.getBlocks().size(),2);
-}
-
-TEST_F(BlocksTest, StartRemoveBlocks) {
-
-  ValidBlock vb1("vb1");
-  scheme.addBlock(&vb1);
-  scheme.start();
-  
-  EXPECT_FALSE(scheme.removeBlock("vb1"));
-  EXPECT_EQ(scheme.getBlocks().size(),1);
-  
-  scheme.stop();
-  
-  EXPECT_TRUE(scheme.removeBlock("vb1"));
-  EXPECT_EQ(scheme.getBlocks().size(),0);
-}
-
-class GroupsTest : public SchemeTest { 
-public:
-  GroupsTest() : SchemeTest(),
-    vb1("vb1"),
-    vb2("vb2"),
-    vb3("vb3")
-  {
-    scheme.addBlock(&vb1);
-    scheme.addBlock(&vb2);
-    scheme.addBlock(&vb3);
-  }
-
-  ValidBlock vb1;
-  ValidBlock vb2;
-  ValidBlock vb3;
-};
-
-TEST_F(GroupsTest, GetGroups) {
-  EXPECT_FALSE(scheme.hasGroup("fail"));
-
-  std::vector<std::string> members;
-  EXPECT_FALSE(scheme.getGroupMembers("fail",members));
-}
-
-TEST_F(GroupsTest, AddGroups) {
-  EXPECT_TRUE(scheme.addGroup(""));
-  EXPECT_TRUE(scheme.addGroup("win"));
-  EXPECT_TRUE(scheme.addGroup("win"));
-}
-
-TEST_F(GroupsTest, SetGroups) {
-  std::vector<std::string> members;
-
-  EXPECT_TRUE(scheme.setGroupMembers("",members));
-  EXPECT_TRUE(scheme.setGroupMembers("win",members));
-
-  members.push_back("not_a_peer");
-  EXPECT_FALSE(scheme.setGroupMembers("fail",members));
-
-}
-
-TEST_F(GroupsTest, AddToGroups) {
-  std::vector<std::string> members, members_get;
-
-  EXPECT_FALSE(scheme.addToGroup("fail",""));
-
-  EXPECT_FALSE(scheme.addToGroup("vb1","win"));
-  EXPECT_TRUE(scheme.addGroup("win"));
-  EXPECT_TRUE(scheme.addToGroup("vb1","win"));
-  EXPECT_TRUE(scheme.addToGroup("vb2","win"));
-  // Add it again
-  EXPECT_TRUE(scheme.addToGroup("vb2","win"));
-
-  EXPECT_TRUE(scheme.getGroupMembers("win",members_get));
-  EXPECT_EQ(members_get.size(),2);
-
-  EXPECT_THAT(members_get, ElementsAre("vb1","vb2"));
-}
-
-TEST_F(GroupsTest, NestedGroups) {
-  std::vector<std::string> members, members_get;
-
-  EXPECT_TRUE(scheme.setGroupMembers("win1","vb1"));
-  EXPECT_TRUE(scheme.setGroupMembers("win2","vb2"));
-  EXPECT_TRUE(scheme.setGroupMembers("win3","vb3"));
-  EXPECT_TRUE(scheme.addGroup("win4"));
-
-  std::vector<std::string> win123_members;
-  win123_members += "win1", "win2", "win3", "win4", "win123";
-
-  EXPECT_TRUE(scheme.setGroupMembers("win123",win123_members));
-
-  EXPECT_TRUE(scheme.getGroupMembers("win123",members_get));
-  EXPECT_EQ(members_get.size(),3);
-}
-
-TEST_F(GroupsTest, RemoveFromGroups) {
-  std::vector<std::string> members, members_get;
-
-  // Add some members
-  EXPECT_TRUE(scheme.setGroupMembers("win1","vb1"));
-  EXPECT_TRUE(scheme.addToGroup("vb2","win1"));
-  EXPECT_TRUE(scheme.getGroupMembers("win1",members_get));
-  EXPECT_EQ(members_get.size(),2);
-
-  // Remove a member
-  EXPECT_TRUE(scheme.removeFromGroup("vb2","win1"));
-  EXPECT_TRUE(scheme.getGroupMembers("win1",members_get));
-  EXPECT_EQ(members_get.size(),1);
-  
-  // Empty the group
-  EXPECT_TRUE(scheme.emptyGroup("win1"));
-  EXPECT_TRUE(scheme.getGroupMembers("win1",members_get));
-  EXPECT_EQ(members_get.size(),0);
-
-  // Empty it again (already empty)
-  EXPECT_TRUE(scheme.emptyGroup("win1"));
-  EXPECT_TRUE(scheme.getGroupMembers("win1",members_get));
-  EXPECT_EQ(members_get.size(),0);
-}
-
-class DataFlowTest : public SchemeTest { 
+class TopoTest : public SchemeTest { 
 public:
   IOBlock iob1;
   IOBlock iob2;
@@ -277,9 +81,9 @@ public:
   IOBlock iob5;
 
   // Expected cycles
-  std::vector<std::string> c1,c2,c3,c4;
+  std::vector<std::string> c1;//,c2,c3,c4;
 
-  DataFlowTest() : SchemeTest(),
+  TopoTest() : SchemeTest(),
     iob1("iob1"),
     iob2("iob2"),
     iob3("iob3"),
@@ -288,9 +92,9 @@ public:
   {
     // Expected cycles
     c1 += "iob1", "iob2", "iob3", "iob4", "iob5";
-    c2 += "iob1", "iob3", "iob4", "iob5";
-    c3 += "iob1", "iob5";
-    c4 += "iob2", "iob3", "iob4", "iob5";
+    //c2 += "iob1", "iob3", "iob4", "iob5";
+    //c3 += "iob1", "iob5";
+    //c4 += "iob2", "iob3", "iob4", "iob5";
   }
 
   void AddBlocks() {
@@ -303,17 +107,17 @@ public:
 
   void ConnectBlocksAcyclic() {
     iob1.out1.connectTo(&iob2.in);
-    iob1.out2.connectTo(&iob3.in_ex);
-    iob2.out1.connectTo(&iob3.in_ex);
+    //iob1.out2.connectTo(&iob3.in_ex);
+    //iob2.out1.connectTo(&iob3.in_ex);
     iob2.out2.connectTo(&iob3.in);
     iob3.out1.connectTo(&iob4.in);
-    iob1.out1.connectTo(&iob5.in);
+    //iob1.out1.connectTo(&iob5.in);
     iob4.out1.connectTo(&iob5.in);
   }
 
   void ConnectBlocksCyclic() {
     iob5.out1.connectTo(&iob1.in);
-    iob5.out2.connectTo(&iob2.in);
+    //iob5.out2.connectTo(&iob2.in);
   }
 
   void PrintCycles(std::vector<std::vector<std::string> > &cycles) {
@@ -328,71 +132,16 @@ public:
   }
 };
 
-TEST_F(DataFlowTest, Acyclic) {
-  // Connect blocks without cycles
-  ConnectBlocksAcyclic();
-  AddBlocks();
-  EXPECT_TRUE(scheme.executable());
-}
-
-TEST_F(DataFlowTest, Cyclic) {
-  // Connect blocks without cycles
-  ConnectBlocksAcyclic();
-  AddBlocks();
-  EXPECT_TRUE(scheme.executable());
-  // Add some cycles
-  ConnectBlocksCyclic();
-  // At this point the model is out-of-sync with the actual DFG
-  EXPECT_TRUE(scheme.executable());
-  scheme.regenerateModel();
-  EXPECT_FALSE(scheme.executable());
-}
-
-TEST_F(DataFlowTest, GetCycles) {
-  // Connect blocks with cycles
-  ConnectBlocksAcyclic();
-  ConnectBlocksCyclic();
-  AddBlocks();
-  EXPECT_FALSE(scheme.executable());
-
-  // Get the cycles
-  std::vector<std::vector<std::string> > flow_cycles, exec_cycles;
-
-  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
-  EXPECT_THAT(flow_cycles, ElementsAre(c1,c2,c3,c4));
-
-  //PrintCycles(flow_cycles);
-
-  EXPECT_EQ(4,scheme.getExecutionCycles(exec_cycles));
-  EXPECT_THAT(exec_cycles, ElementsAre(c1,c2,c3,c4));
-}
-
-TEST_F(DataFlowTest, LatchConnections) {
+TEST_F(TopoTest, StartTopo) {
   std::vector<std::vector<std::string> > flow_cycles, exec_cycles;
 
   // Connect blocks with cycles
   ConnectBlocksAcyclic();
   ConnectBlocksCyclic();
   AddBlocks();
-
-  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
-  EXPECT_THAT(flow_cycles, ElementsAre(c1,c2,c3,c4));
-  EXPECT_EQ(4,scheme.getExecutionCycles(exec_cycles));
-  EXPECT_THAT(exec_cycles, ElementsAre(c1,c2,c3,c4));
 
   EXPECT_TRUE(scheme.latchConnections("iob5","iob1",true));
-
-  EXPECT_FALSE(scheme.executable());
-
-  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
-  EXPECT_THAT(flow_cycles, ElementsAre(c1,c2,c3,c4));
-  EXPECT_EQ(1,scheme.getExecutionCycles(exec_cycles));
-  EXPECT_THAT(exec_cycles, ElementsAre(c4));
-
-  EXPECT_TRUE(scheme.latchConnections("iob5","iob2",true));
-
-  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
-  EXPECT_THAT(flow_cycles, ElementsAre(c1,c2,c3,c4));
+  EXPECT_EQ(1,scheme.getFlowCycles(flow_cycles));
   EXPECT_EQ(0,scheme.getExecutionCycles(exec_cycles));
   EXPECT_TRUE(scheme.executable());
 
@@ -401,75 +150,10 @@ TEST_F(DataFlowTest, LatchConnections) {
   EXPECT_TRUE(scheme.getExecutionOrder(execution_order));
 
   EXPECT_THAT(execution_order, ElementsAre("iob1", "iob2", "iob3", "iob4", "iob5"));
-}
 
-TEST_F(DataFlowTest, Latchanalysis) {
-  std::vector<std::vector<std::string> > flow_cycles, exec_cycles;
-
-  // Connect blocks with cycles
-  ConnectBlocksAcyclic();
-  ConnectBlocksCyclic();
-  AddBlocks();
-
-  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
-  EXPECT_EQ(4,scheme.getExecutionCycles(exec_cycles));
-
-  scheme.latchConnections("iob5","iob1",true);
-  scheme.latchConnections("iob5","iob2",true);
-
-  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
-  EXPECT_EQ(0,scheme.getExecutionCycles(exec_cycles));
-
-  std::vector<std::string> path_query1, path_query2;
-  path_query1 += "iob1", "iob2", "iob3", "iob4", "iob5";
-  EXPECT_EQ(0,scheme.latchCount(path_query1));
-  path_query2 += "iob5","iob1";
-  EXPECT_EQ(1,scheme.latchCount(path_query2));
-
-  EXPECT_EQ(4,scheme.getFlowCycles(flow_cycles));
-  EXPECT_EQ(0,scheme.getExecutionCycles(exec_cycles));
-
-  EXPECT_EQ(1,scheme.maxLatchCount());
-  EXPECT_EQ(1,scheme.minLatchCount());
-}
-
-TEST_F(DataFlowTest, StartAcyclic) {
-  // Connect blocks without cycles
-  ConnectBlocksAcyclic();
-  AddBlocks();
-  EXPECT_TRUE(scheme.start());
-}
-
-TEST_F(DataFlowTest, StartCyclic) {
-  // Connect blocks without cycles
-  ConnectBlocksAcyclic();
-  AddBlocks();
-  EXPECT_TRUE(scheme.start());
-  scheme.stop();
-  // Add some cycles
-  ConnectBlocksCyclic();
-  EXPECT_FALSE(scheme.start());
-}
-
-TEST_F(DataFlowTest, StartLatchConnections) {
-  std::vector<std::vector<std::string> > flow_cycles, exec_cycles;
-
-  // Connect blocks with cycles
-  ConnectBlocksAcyclic();
-
-  AddBlocks();
-
+  //OK GAME TIME
   scheme.start();
-
-  ConnectBlocksCyclic();
-  EXPECT_FALSE(scheme.regenerateModel());
-  EXPECT_FALSE(scheme.latchConnections("iob5","iob1",true));
-
   scheme.stop();
-  EXPECT_FALSE(scheme.regenerateModel());
-  EXPECT_TRUE(scheme.latchConnections("iob5","iob1",true));
-  EXPECT_TRUE(scheme.latchConnections("iob5","iob2",true));
-  EXPECT_TRUE(scheme.regenerateModel());
 }
 
 int main(int argc, char** argv) {

--- a/conman/tests/test_topo.cpp
+++ b/conman/tests/test_topo.cpp
@@ -29,6 +29,8 @@ using namespace boost::assign;
 #include <gmock/gmock.h>
 using ::testing::ElementsAre;
 
+std::vector<std::string> enable_Order;
+std::vector<std::string> disable_Order;
 
 class InvalidBlock : public RTT::TaskContext {
 public:
@@ -81,7 +83,7 @@ public:
   IOBlock iob5;
 
   // Expected cycles
-  std::vector<std::string> c1;//,c2,c3,c4;
+  std::vector<std::string> c1;
 
   TopoTest() : SchemeTest(),
     iob1("iob1"),
@@ -90,11 +92,8 @@ public:
     iob4("iob4"),
     iob5("iob5")
   {
-    // Expected cycles
+    // Expected cycle
     c1 += "iob1", "iob2", "iob3", "iob4", "iob5";
-    //c2 += "iob1", "iob3", "iob4", "iob5";
-    //c3 += "iob1", "iob5";
-    //c4 += "iob2", "iob3", "iob4", "iob5";
   }
 
   void AddBlocks() {
@@ -107,17 +106,13 @@ public:
 
   void ConnectBlocksAcyclic() {
     iob1.out1.connectTo(&iob2.in);
-    //iob1.out2.connectTo(&iob3.in_ex);
-    //iob2.out1.connectTo(&iob3.in_ex);
     iob2.out2.connectTo(&iob3.in);
     iob3.out1.connectTo(&iob4.in);
-    //iob1.out1.connectTo(&iob5.in);
     iob4.out1.connectTo(&iob5.in);
   }
 
   void ConnectBlocksCyclic() {
     iob5.out1.connectTo(&iob1.in);
-    //iob5.out2.connectTo(&iob2.in);
   }
 
   void PrintCycles(std::vector<std::vector<std::string> > &cycles) {
@@ -150,9 +145,11 @@ TEST_F(TopoTest, StartTopo) {
   EXPECT_TRUE(scheme.getExecutionOrder(execution_order));
 
   EXPECT_THAT(execution_order, ElementsAre("iob1", "iob2", "iob3", "iob4", "iob5"));
-
-  //OK GAME TIME
+  
   scheme.start();
+  std::vector<std::string> &ptr_blocks = execution_order;
+  EXPECT_TRUE(scheme.enableBlocksTopo(ptr_blocks, true, true));
+  EXPECT_TRUE(scheme.disableBlocksTopo(ptr_blocks, true));
   scheme.stop();
 }
 


### PR DESCRIPTION
Two new functions which allow you to enable a list of blocks in topographical order and disable in reverse topographical order. There is also a new test file which tests that the functions correctly reorder the list of blocks, enable or disable them, and there are two tests for the start and end hooks written to keep track of enable/disable order.